### PR TITLE
mark-devkit: Bump dev-python/brotlipy-1.1.0

### DIFF
--- a/dev-python/brotlipy/brotlipy-1.1.0.ebuild
+++ b/dev-python/brotlipy/brotlipy-1.1.0.ebuild
@@ -1,0 +1,21 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3+ )
+inherit distutils-r1
+
+DESCRIPTION=""
+HOMEPAGE=""
+
+DEPEND="app-arch/brotli"
+RDEPEND="${DEPEND}"
+IUSE=""
+SLOT="0"
+LICENSE=""
+KEYWORDS="*"
+S="${WORKDIR}/brotli-1.1.0"
+
+src_unpack() {
+	unpack ${ROOT}/usr/share/brotli/bindings/brotli-python-${PV}.tar.gz || die
+}


### PR DESCRIPTION
Automatic bump of package dev-python/brotlipy-1.1.0 for branch mark-xl by mark-bot