### PR TITLE
mark-devkit: Bump virtual/python-cffi-0

### DIFF
--- a/virtual/python-cffi/python-cffi-0.ebuild
+++ b/virtual/python-cffi/python-cffi-0.ebuild
@@ -1,0 +1,12 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3+ )
+
+inherit python-r1
+SLOT="0"
+KEYWORDS="*"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS} dev-python/cffi[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Automatic bump of package virtual/python-cffi-0 for branch mark-xl by mark-bot