### PR TITLE
mark-devkit: Bump dev-python/sphinx-7.4.7-r1

### DIFF
--- a/dev-python/sphinx/sphinx-7.4.7-r1.ebuild
+++ b/dev-python/sphinx/sphinx-7.4.7-r1.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	dev-python/sphinxcontrib-serializinghtml[${PYTHON_USEDEP}]"
 IUSE="doc latex"
 SLOT="0"
-LICENSE="BSD"
+LICENSE=""
 KEYWORDS="*"
 S="${WORKDIR}/sphinx-7.4.7"
 


### PR DESCRIPTION
Automatic bump of package dev-python/sphinx-7.4.7-r1 for branch mark-unstable by mark-bot