### PR TITLE
mark-devkit: Bump virtual/python-typing-0-r1

### DIFF
--- a/virtual/python-typing/python-typing-0-r1.ebuild
+++ b/virtual/python-typing/python-typing-0-r1.ebuild
@@ -1,0 +1,12 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3+ )
+
+inherit python-r1
+SLOT="0"
+KEYWORDS="*"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS} $(python_gen_cond_dep 'dev-python/typing[${PYTHON_USEDEP}]' -2)"


### PR DESCRIPTION
Automatic bump of package virtual/python-typing-0-r1 for branch mark-xl by mark-bot