### PR TITLE
mark-devkit: Bump dev-python/platformdirs-4.3.6-r1

### DIFF
--- a/dev-python/platformdirs/platformdirs-4.3.6-r1.ebuild
+++ b/dev-python/platformdirs/platformdirs-4.3.6-r1.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3+ )
 DISTUTILS_USE_PEP517="hatchling"
 inherit distutils-r1
 
-DESCRIPTION="A small Python package for determining appropriate platform-specific dirs"
+DESCRIPTION="A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 HOMEPAGE="None https://pypi.org/project/platformdirs/"
 SRC_URI="https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz -> platformdirs-4.3.6.tar.gz"
 


### PR DESCRIPTION
Automatic bump of package dev-python/platformdirs-4.3.6-r1 for branch mark-xl by mark-bot