### PR TITLE
mark-devkit: Bump dev-python/platformdirs-4.3.7-r1

### DIFF
--- a/dev-python/platformdirs/platformdirs-4.3.7-r1.ebuild
+++ b/dev-python/platformdirs/platformdirs-4.3.7-r1.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3+ )
 DISTUTILS_USE_PEP517="hatchling"
 inherit distutils-r1
 
-DESCRIPTION="A small Python package for determining appropriate platform-specific dirs"
+DESCRIPTION="A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 HOMEPAGE="None https://pypi.org/project/platformdirs/"
 SRC_URI="https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz -> platformdirs-4.3.7.tar.gz"
 


### PR DESCRIPTION
Automatic bump of package dev-python/platformdirs-4.3.7-r1 for branch mark-xl by mark-bot