### PR TITLE
mark-devkit: Bump dev-python/jinja-3.1.6-r1

### DIFF
--- a/dev-python/jinja/jinja-3.1.6-r1.ebuild
+++ b/dev-python/jinja/jinja-3.1.6-r1.ebuild
@@ -1,4 +1,5 @@
 # Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
 
 EAPI=7
 
@@ -8,36 +9,27 @@ inherit distutils-r1
 
 DESCRIPTION="A full-featured template engine for Python"
 HOMEPAGE="https://palletsprojects.com/p/jinja/ https://pypi.org/project/Jinja2/"
-SRC_URI="https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz -> jinja2-3.1.6.tar.gz"
+SRC_URI="https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz -> jinja2-3.1.6.tar.gz
+"
+RDEPEND="dev-python/markupsafe[${PYTHON_USEDEP}]
+"
+BDEPEND="dev-python/markupsafe[${PYTHON_USEDEP}]
+"
 
-DEPEND=""
-RDEPEND="
-	!dev-python/jinja:compat
-	dev-python/markupsafe[${PYTHON_USEDEP}]"
-IUSE="examples"
-RESTRICT="test"
+IUSE=""
 SLOT="0"
 LICENSE="BSD"
 KEYWORDS="*"
 S="${WORKDIR}/jinja2-3.1.6"
 
-distutils_enable_sphinx docs \
-	dev-python/sphinx-issues \
-	dev-python/pallets-sphinx-themes
 src_prepare() {
 	# avoid unnecessary dep on extra sphinxcontrib modules
 	sed -i '/sphinxcontrib.log_cabinet/ d' docs/conf.py || die
 	distutils-r1_src_prepare
-}
-python_install_all() {
-	if use examples ; then
-		docinto examples
-		dodoc -r examples/.
-	fi
-	distutils-r1_python_install_all
 }
 pkg_postinst() {
 	if ! has_version dev-python/Babel; then
 		elog "For i18n support, please emerge dev-python/Babel."
 	fi
 }
+


### PR DESCRIPTION
Automatic bump of package dev-python/jinja-3.1.6-r1 for branch mark-xl by mark-bot