### PR TITLE
mark-devkit: Bump dev-python/jeepney-0.9.0-r1

### DIFF
--- a/dev-python/jeepney/jeepney-0.9.0-r1.ebuild
+++ b/dev-python/jeepney/jeepney-0.9.0-r1.ebuild
@@ -1,0 +1,17 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+PYTHON_COMPAT=( python3+ )
+DISTUTILS_USE_PEP517="standalone"
+inherit distutils-r1
+
+DESCRIPTION="Low-level, pure Python DBus protocol wrapper."
+HOMEPAGE="https://gitlab.com/takluyver/jeepney"
+SRC_URI="https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz -> jeepney-0.9.0.tar.gz
+"
+SLOT="0"
+LICENSE="MIT"
+KEYWORDS="*"
+S="${WORKDIR}/jeepney-0.9.0"


### PR DESCRIPTION
Automatic bump of package dev-python/jeepney-0.9.0-r1 for branch mark-iii by mark-bot