### PR TITLE
mark-devkit: Bump dev-python/click-8.1.8-r1

### DIFF
--- a/dev-python/click/click-8.1.8-r1.ebuild
+++ b/dev-python/click/click-8.1.8-r1.ebuild
@@ -12,6 +12,6 @@ SRC_URI="https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b8
 DEPEND=""
 IUSE=""
 SLOT="0"
-LICENSE="BSD"
+LICENSE=""
 KEYWORDS="*"
 S="${WORKDIR}/click-8.1.8"


### PR DESCRIPTION
Automatic bump of package dev-python/click-8.1.8-r1 for branch mark-unstable by mark-bot