### PR TITLE
mark-devkit: Bump dev-python/pyalsa-1.2.7-r1

### DIFF
--- a/dev-python/pyalsa/pyalsa-1.2.7-r1.ebuild
+++ b/dev-python/pyalsa/pyalsa-1.2.7-r1.ebuild
@@ -19,4 +19,4 @@ RDEPEND="media-libs/alsa-lib"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]"
 
-PATCHES=( "${FILESDIR}/${PN}-1.1.6-no-build-symlinks.patch" )
+PATCHES=( "${REPODIR}/media-sound/files/${PN}/${PN}-1.1.6-no-build-symlinks.patch" )


### PR DESCRIPTION
Automatic bump of package dev-python/pyalsa-1.2.7-r1 for branch mark-unstable by mark-bot