### PR TITLE
mark-devkit: [mark-unstable] Bump dev-python/rpi-gpio-0.7.1-r1

### DIFF
--- a/dev-python/rpi-gpio/rpi-gpio-0.7.1-r1.ebuild
+++ b/dev-python/rpi-gpio/rpi-gpio-0.7.1-r1.ebuild
@@ -4,7 +4,6 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3+ )
-DISTUTILS_USE_PEP517="standalone"
 inherit distutils-r1
 
 DESCRIPTION="A module to control Raspberry Pi GPIO channels"


### PR DESCRIPTION
Automatic bump of package dev-python/rpi-gpio-0.7.1-r1 for branch mark-unstable by mark-bot