### PR TITLE
mark-devkit: [mark-iii] Bump dev-python/brotlipy-1.2.0-r1

### DIFF
--- a/dev-python/brotlipy/brotlipy-1.2.0-r1.ebuild
+++ b/dev-python/brotlipy/brotlipy-1.2.0-r1.ebuild
@@ -14,4 +14,4 @@ SRC_URI="https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353
 SLOT="0"
 LICENSE="MIT"
 KEYWORDS="*"
-S="${WORKDIR}/Brotli-1.2.0"
+S="${WORKDIR}/brotli-1.2.0"


### PR DESCRIPTION
Automatic bump of package dev-python/brotlipy-1.2.0-r1 for branch mark-iii by mark-bot