### PR TITLE
mark-devkit: [mark-iii] Bump dev-python/yarl-1.22.0-r1

### DIFF
--- a/dev-python/yarl/yarl-1.22.0-r1.ebuild
+++ b/dev-python/yarl/yarl-1.22.0-r1.ebuild
@@ -28,6 +28,10 @@ LICENSE="Apache-2.0"
 KEYWORDS="*"
 S="${WORKDIR}/yarl-1.22.0"
 
+src_prepare() {
+	sed -i -e '/^freethreading_compatible/d'  pyproject.toml
+	default
+}
 python_compile() {
 	local -x YARL_NO_EXTENSIONS=0
 	if ! use native-extensions || [[ ${EPYTHON} != python* ]]; then


### PR DESCRIPTION
Automatic bump of package dev-python/yarl-1.22.0-r1 for branch mark-iii by mark-bot