### PR TITLE
mark-devkit: [mark-iii] Bump dev-python/libxml2-python-2.15.1-r1

### DIFF
--- a/dev-python/libxml2-python/libxml2-python-2.15.1-r1.ebuild
+++ b/dev-python/libxml2-python/libxml2-python-2.15.1-r1.ebuild
@@ -12,6 +12,7 @@ SLOT="2"
 KEYWORDS="*"
 IUSE="+icu +lzma readline static-libs"
 RDEPEND="=dev-libs/libxml2-2.15.1:=[lzma?,icu?,readline?,static-libs?]
+!<dev-python/libxml2-python-2.15.0
 	
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Automatic bump of package dev-python/libxml2-python-2.15.1-r1 for branch mark-iii by mark-bot