### PR TITLE
mark-devkit: [mark-xl] Bump dev-python/libxml2-python-2.15.2-r1

### DIFF
--- a/dev-python/libxml2-python/libxml2-python-2.15.2-r1.ebuild
+++ b/dev-python/libxml2-python/libxml2-python-2.15.2-r1.ebuild
@@ -23,8 +23,8 @@ src_prepare() {
 	default
 	sed -e "/^dir_doc/ s/meson.project_name()$/\'${PF}\'/" -i meson.build || die
 	# Permit to compile libxml2 on stage3 without git installed.
-	local# Hack git command with echo in order to print an empty string.
-	sed -src_configuree 's|git|echo|g' -e 's|describe||g' -i meson.build || die
+	# Hack git command with echo in order to print an empty string.
+	sed -e 's|git|echo|g' -e 's|describe||g' -i meson.build || die
 }
 src_configure() {
 	local emesonargs=(


### PR DESCRIPTION
Automatic bump of package dev-python/libxml2-python-2.15.2-r1 for branch mark-xl by mark-bot