### PR TITLE
mark-devkit: [mark-31] Bump dev-python/cryptography-46.0.6-r1

### DIFF
--- a/dev-python/cryptography/cryptography-46.0.6-r1.ebuild
+++ b/dev-python/cryptography/cryptography-46.0.6-r1.ebuild
@@ -39,7 +39,10 @@ src_unpack() {
 }
 python_install() {
 	distutils-r1_python_install
-	rm -r "${D}$(python_get_sitedir)"/tests || die
+	if [ -e "${D}$(python_get_sitedir)/tests" ] ; then
+		einfo "Removing $(python_get_sitedir)/tests directory..."
+		rm -r "${D}$(python_get_sitedir)"/tests || die
+	fi
 }
 
 


### PR DESCRIPTION
Automatic bump of package dev-python/cryptography-46.0.6-r1 for branch mark-31 by mark-bot