### PR TITLE
mark-devkit: [mark-iii] Bump dev-python/libxml2-python-2.15.2-r1

### DIFF
--- a/dev-python/libxml2-python/libxml2-python-2.15.2-r1.ebuild
+++ b/dev-python/libxml2-python/libxml2-python-2.15.2-r1.ebuild
@@ -47,7 +47,7 @@ src_compile() {
 src_install() {
 	meson_src_install
 	# Remove files supplied by libxml2 library
-	rm -r "${ED}"/usr/{lib64,bin,include} || die
+	rm -r "${ED}"/usr/{$(get_libdir),bin,include} || die
 }
 
 


### PR DESCRIPTION
Automatic bump of package dev-python/libxml2-python-2.15.2-r1 for branch mark-iii by mark-bot